### PR TITLE
Replace to @electron/remote module

### DIFF
--- a/lib/pomodoro-edit.js
+++ b/lib/pomodoro-edit.js
@@ -1,6 +1,7 @@
 'use babel';
 
-import { remote, ipcRenderer } from 'electron';
+import { ipcRenderer } from 'electron';
+import { app, Menu, Tray } from '@electron/remote';
 import CodeMirror from 'codemirror';
 import { CompositeDisposable } from 'event-kit';
 import Core, { getReplacementRange } from '@seachicken/pomodoro-edit-core';
@@ -14,17 +15,22 @@ export function activate() {
 
   window.addEventListener('unload', () => deactivate());
 
-  const modulePath = `${remote.app.getAppPath()}/node_modules`;
+  const modulePath = `${app.getAppPath()}/node_modules`;
   require(`${modulePath}/codemirror/addon/hint/show-hint`);
 
   if (process.platform === 'win32') {
-    _tray = new remote.Tray(`${__dirname}/../resources/icon.ico`);
+    _tray = new Tray(`${__dirname}/../resources/icon.ico`);
   } else {
-    _tray = new remote.Tray(`${__dirname}/../resources/iconTemplate.png`);
+    _tray = new Tray(`${__dirname}/../resources/iconTemplate.png`);
   }
+
   _core = new Core();
   _core.runServer(62115);
-  _registerCommands();
+
+  if (inkdrop.isEditorActive()) {
+    _registerCommands(inkdrop.getActiveEditor());
+  }
+  inkdrop.onEditorLoad(_registerCommands);
 }
 
 export function deactivate() {
@@ -36,33 +42,31 @@ export function deactivate() {
   _tray.destroy();
 }
 
-function _registerCommands() {
-  inkdrop.onEditorLoad(editor => {
-    const { cm } = editor;
+function _registerCommands(editor) {
+  const { cm } = editor;
 
-    const handlers = {
-      'pomodoro-edit:show-hint': () => {
-        const bullet = inkdrop.config.settings.editor.unorderedListBullet || '*';
-        _showPomodoroTextHint(cm, bullet);
-      },
-      'pomodoro-edit:up-hint': () => {
-        const { widget } = cm.state.completionActive;
-        widget.changeActive(widget.selectedHint - 1);
-      },
-      'pomodoro-edit:down-hint': () => {
-        const { widget } = cm.state.completionActive;
-        widget.changeActive(widget.selectedHint + 1);
-      },
-      'pomodoro-edit:select-hint': () => {
-        const { widget } = cm.state.completionActive;
-        widget.pick();
-      },
-      'pomodoro-edit:close-hint': () => {
-        cm.closeHint();
-      }
-    };
-    _disposables.add(inkdrop.commands.add(cm.getWrapperElement(), handlers));
-  });
+  const handlers = {
+    'pomodoro-edit:show-hint': () => {
+      const bullet = inkdrop.config.settings.editor.unorderedListBullet || '*';
+      _showPomodoroTextHint(cm, bullet);
+    },
+    'pomodoro-edit:up-hint': () => {
+      const { widget } = cm.state.completionActive;
+      widget.changeActive(widget.selectedHint - 1);
+    },
+    'pomodoro-edit:down-hint': () => {
+      const { widget } = cm.state.completionActive;
+      widget.changeActive(widget.selectedHint + 1);
+    },
+    'pomodoro-edit:select-hint': () => {
+      const { widget } = cm.state.completionActive;
+      widget.pick();
+    },
+    'pomodoro-edit:close-hint': () => {
+      cm.closeHint();
+    }
+  };
+  _disposables.add(inkdrop.commands.add(cm.getWrapperElement(), handlers));
 
   _disposables.add(inkdrop.commands.add(document.body, "core:save-note", () => {
     const { editingNote } = inkdrop.store.getState();
@@ -115,7 +119,7 @@ function _updateTrayOnInterval(remainingSec, stepNos, symbol, ptext) {
 
 function _configureMenu(ptext, stepNos, symbol) {
   const blank = symbol || stepNos ? ' ' : '';
-  _tray.setContextMenu(remote.Menu.buildFromTemplate([
+  _tray.setContextMenu(Menu.buildFromTemplate([
       { label: `${ptext.content}${blank}${symbol || ''}${stepNos ? '#' + stepNos : ''}`,
         submenu: [
           { label: 'Go to Line', click: () => _goToLineToCheckbox(ptext) },
@@ -141,7 +145,7 @@ function _goToLine(ptext, ch) {
   let cnt = 0;
   const interval = setInterval(() => {
     cnt++;
-    if (inkdrop.activeEditor.props.noteId === ptext.id) {
+    if (inkdrop.isEditorActive() && inkdrop.activeEditor.props.noteId === ptext.id) {
       inkdrop.commands.dispatch(document.body, 'editor:focus-mde');
       inkdrop.activeEditor.cm.setCursor(ptext.line, ch)
       clearInterval(interval);


### PR DESCRIPTION
Fixes #7 

>require('electron').remote is no longer available for plugins. Use require('@electron/remote') instead.

https://github.com/inkdropapp/version-history#breaking-changes